### PR TITLE
feat: create sales details page

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,7 +6,8 @@
     "pages/products/addProduct",
     "pages/products/editProduct",
     "pages/sales/sales",
-    "pages/sales-list/index"
+    "pages/sales-list/index",
+    "pages/sales-detail/index"
   ],
   "window": {
     "defaultTitle": "UMKM Invoicing"

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -54,5 +54,8 @@
   "sales_list_total": "Today's Total Sales",
   "sales_list_order_prefix": "Order #",
   "sales_list_add": "Add",
-  "sales_list_loading": "Loading..."
+  "sales_list_loading": "Loading...",
+  "sales_detail_order": "Order #",
+  "sales_detail_total": "Total Payment",
+  "sales_detail_print": "Print Receipt"
 }

--- a/i18n/id.json
+++ b/i18n/id.json
@@ -54,5 +54,8 @@
   "sales_list_total": "Total Penjualan Hari Ini",
   "sales_list_order_prefix": "Order #",
   "sales_list_add": "Tambah",
-  "sales_list_loading": "Memuat..."
+  "sales_list_loading": "Memuat...",
+  "sales_detail_order": "Order #",
+  "sales_detail_total": "Total Pembayaran",
+  "sales_detail_print": "Cetak Nota"
 }

--- a/pages/sales-detail/index.acss
+++ b/pages/sales-detail/index.acss
@@ -1,0 +1,89 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  width: 100%;
+  background: #f5f5f5;
+  overflow: hidden;
+}
+
+.header {
+  width: 100%;
+  padding: 16px;
+  background: #fff;
+  box-sizing: border-box;
+}
+
+.content {
+  flex: 1;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.products-list {
+  margin: 16px;
+  background: #fff;
+  border-radius: 8px;
+  width: calc(100% - 32px);
+  box-sizing: border-box;
+}
+
+.product-item {
+  display: flex;
+  justify-content: space-between;
+  padding: 16px;
+  border-bottom: 1px solid #f5f5f5;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.product-info {
+  flex: 1;
+  padding-right: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.product-name {
+  font-size: 16px;
+}
+
+.product-detail {
+  font-size: 14px;
+  color: #666;
+}
+
+.product-subtotal {
+  font-size: 16px;
+  font-weight: 500;
+}
+
+.total-section {
+  margin: 0 16px 16px;
+  padding: 16px;
+  background: #fff;
+  border-radius: 8px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: calc(100% - 32px);
+  box-sizing: border-box;
+}
+
+.actions {
+  width: 100%;
+  padding: 16px;
+  background: #fff;
+  border-top: 1px solid #f0f0f0;
+  box-sizing: border-box;
+}
+
+.print-button {
+  width: 100%;
+  height: 44px;
+  background: #1677ff;
+  color: #fff;
+  border-radius: 8px;
+  font-size: 16px;
+}

--- a/pages/sales-detail/index.axml
+++ b/pages/sales-detail/index.axml
@@ -1,0 +1,28 @@
+<view class="container">
+  <view class="header">
+    <text class="title">{{orderPrefix}}{{orderNo}}</text>
+  </view>
+
+  <scroll-view class="content" scroll-y="{{true}}">
+    <view class="products-list">
+      <block a:for="{{products}}" a:key="*this">
+        <view class="product-item">
+          <view class="product-info">
+            <text class="product-name">{{item.name}}</text>
+            <text class="product-detail">{{item.qty}} x Rp {{item.price}}</text>
+          </view>
+          <text class="product-subtotal">Rp {{item.subtotal}}</text>
+        </view>
+      </block>
+    </view>
+
+    <view class="total-section">
+      <text class="total-label">{{totalLabel}}</text>
+      <text class="total-amount">Rp {{totalPrice}}</text>
+    </view>
+  </scroll-view>
+
+  <view class="actions">
+    <button class="print-button" onTap="onPrintReceipt">{{printLabel}}</button>
+  </view>
+</view>

--- a/pages/sales-detail/index.js
+++ b/pages/sales-detail/index.js
@@ -1,0 +1,55 @@
+const { t } = require('../../utils/i18n');
+
+const formatCurrency = (amount) => {
+  return amount.toLocaleString('id-ID');
+};
+
+Page({
+  data: {
+    orderNo: '',
+    products: [],
+    totalPrice: 0
+  },
+
+  onLoad(query) {
+    const { id } = query;
+    this.setLabels();
+    this.loadSalesDetail(id);
+  },
+
+  onShow() {
+    this.setLabels();
+  },
+
+  setLabels() {
+    this.setData({
+      orderPrefix: t('sales_detail_order'),
+      totalLabel: t('sales_detail_total'),
+      printLabel: t('sales_detail_print')
+    });
+  },
+
+  loadSalesDetail(id) {
+    // Dummy data for demonstration
+    const products = [
+      { name: 'Product 1', qty: 2, price: 50000, subtotal: 100000 },
+      { name: 'Product 2', qty: 1, price: 75000, subtotal: 75000 }
+    ];
+
+    this.setData({
+      orderNo: id,
+      products: products.map(item => ({
+        ...item,
+        price: formatCurrency(item.price),
+        subtotal: formatCurrency(item.subtotal)
+      })),
+      totalPrice: formatCurrency(products.reduce((sum, item) => sum + item.subtotal, 0))
+    });
+  },
+
+  onPrintReceipt() {
+    my.showToast({
+      content: t('print_coming_soon')
+    });
+  }
+});

--- a/pages/sales-list/index.axml
+++ b/pages/sales-list/index.axml
@@ -13,7 +13,7 @@
   <view class="content-area">
     <scroll-view class="sales-list" scroll-y="{{true}}" onScrollToLower="loadMoreSales" lower-threshold="50">
       <block a:for="{{salesList}}" a:key="receiptNo">
-        <view class="sales-item">
+        <view class="sales-item" onTap="onSalesItemTap" data-receipt-no="{{item.receiptNo}}">
           <text class="order-no">{{orderPrefix}}{{item.receiptNo.split('/')[0]}}</text>
           <text class="amount">Rp {{item.totalPrice}}</text>
         </view>

--- a/pages/sales-list/index.js
+++ b/pages/sales-list/index.js
@@ -1,5 +1,9 @@
 const { t } = require('../../utils/i18n');
 
+const formatCurrency = (amount) => {
+  return amount.toLocaleString('id-ID');
+};
+
 Page({
   data: {
     salesList: [],
@@ -36,14 +40,20 @@ Page({
   generateDummyData() {
     this.setData({ loading: true });
     
-    const dummyData = Array.from({ length: 10 }, (_, i) => ({
-      receiptNo: `${i + 1}/INV/2024`,
-      totalPrice: Math.floor(Math.random() * 1000000).toLocaleString()
-    }));
+    const dummyData = Array.from({ length: 10 }, (_, i) => {
+      const price = Math.floor(Math.random() * 1000000);
+      return {
+        receiptNo: `${i + 1}/INV/2024`,
+        totalPrice: formatCurrency(price)
+      };
+    });
+
+    const totalSales = dummyData.reduce((sum, item) => 
+      sum + parseInt(item.totalPrice.replace(/[.,]/g, '')), 0);
 
     this.setData({
       salesList: dummyData,
-      totalSales: '5,000,000',
+      totalSales: formatCurrency(totalSales),
       loading: false
     });
   },
@@ -55,10 +65,13 @@ Page({
     
     setTimeout(() => {
       const currentTotal = this.data.salesList.length;
-      const newData = Array.from({ length: this.data.pageSize }, (_, i) => ({
-        receiptNo: `${currentTotal + i + 1}/INV/2024`,
-        totalPrice: Math.floor(Math.random() * 1000000).toLocaleString()
-      }));
+      const newData = Array.from({ length: this.data.pageSize }, (_, i) => {
+        const price = Math.floor(Math.random() * 1000000);
+        return {
+          receiptNo: `${currentTotal + i + 1}/INV/2024`,
+          totalPrice: formatCurrency(price)
+        };
+      });
       
       this.setData({
         salesList: [...this.data.salesList, ...newData],
@@ -66,5 +79,12 @@ Page({
         hasMore: (currentTotal + newData.length) < 100
       });
     }, 500);
+  },
+
+  onSalesItemTap(e) {
+    const { receiptNo } = e.target.dataset;
+    my.navigateTo({
+      url: `/pages/sales-detail/index?id=${receiptNo.split('/')[0]}`
+    });
   }
 });


### PR DESCRIPTION
Creates a new sales details page containg the details of the selected sales from sales list page. This page is still using the dummy data.

<img width="421" alt="Screenshot 2025-06-18 at 11 28 09" src="https://github.com/user-attachments/assets/0c224ddc-c86c-441c-9deb-f7e3e7883392" />
